### PR TITLE
파일구조 수정 및 리프레시토큰으로 인한 리스트api 관련 오류 수정

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -2,8 +2,6 @@ import { createContext, useContext, useState, useEffect } from 'react';
 
 const AuthContext = createContext();
 
-let refreshPromise = null; // 리프레시 중이면 공유할 Promise
-
 export const AuthProvider = ({ children }) => {
   const [loginCheck, setLoginCheck] = useState(null);
   const [loading, setLoading] = useState(true); // 화면 렌더링 지연하려는 용도!!
@@ -18,13 +16,12 @@ export const AuthProvider = ({ children }) => {
 
   const initAuth = async () => {
     const accessToken = localStorage.getItem('jwt');
-    //console.log('JWT 초기값:', accessToken);
 
     if (!accessToken) {
       console.log('accessToken 없음');
       setLoginCheck(false);
       setLoading(false);
-      return;
+      return; // return 추가로 아래 코드 실행 방지
     }
 
     try {
@@ -38,40 +35,25 @@ export const AuthProvider = ({ children }) => {
       });
 
       const data = await res.json();
-     // console.log('validate 응답:', data);
+      console.log('validate 응답:', data);
+      console.log('data.valid:', data.valid);
+      console.log('data.memberDto:', data.memberDto);
+      console.log('data.memberDto?.memId:', data.memberDto?.memId);
 
       if (res.ok && data.valid) {
         setLoginCheck(true);
-        setMemberInfo(data.memberDto)
-        setMemId(data.memberDto.memId)
-        console.log("멤버아이디",data.memberDto.memId);
+        setMemberInfo(data.memberDto);
+        setMemId(data.memberDto?.memId); // 옵셔널 체이닝
+        console.log("멤버아이디", data.memberDto?.memId);
       } else {
-        //console.log('토큰 만료 → 리프레시 시도');
-
-        // refresh 요청이 이미 진행 중이라면 대기
-        if (!refreshPromise) {
-            refreshPromise = fetch('http://localhost:8888/spark/api/refresh', {
-            method: 'POST',
-            credentials: 'include',
-          }).then((res) => res.json());
-        }
-
-        const refreshData = await refreshPromise;
-        refreshPromise = null; // Promise 초기화
-
-        if (refreshData.accessToken) {
-          //console.log('새 토큰 저장:', refreshData.accessToken);
-          localStorage.setItem('jwt', refreshData.accessToken);
-          setLoginCheck(true);
-        } else {
-          //console.log('refresh 실패');
-          localStorage.removeItem('jwt');
-          setLoginCheck(false);
-        }
+        localStorage.removeItem('jwt');
+        setLoginCheck(false);
+        console.log('validate 실패 또는 만료:', data);
       }
     } catch (err) {
       localStorage.removeItem('jwt');
       setLoginCheck(false);
+      console.log('validate 에러:', err);
     } finally {
       // 렌더링 타이밍 지연
       await new Promise((res) => setTimeout(res, 100));
@@ -79,10 +61,19 @@ export const AuthProvider = ({ children }) => {
     }
   };
 
+
+
+
     useEffect(() => {
-      
+
       initAuth();
+
     }, []);
+
+
+
+
+
 
   return (
     <AuthContext.Provider value={{ loginCheck, 
@@ -93,7 +84,8 @@ export const AuthProvider = ({ children }) => {
                                    setMemberInfo,
                                    step,
                                    setStep,
-                                   memId
+                                   memId,
+                                   setMemId 
                                      }}>  
                                    
                                    {children} </AuthContext.Provider>

--- a/src/page/Home/Home.jsx
+++ b/src/page/Home/Home.jsx
@@ -7,6 +7,7 @@ import { FiAlertCircle } from "react-icons/fi";
 import HomeModal from '../../component/modal/HomeModal';
 import AlertModal from '../../component/modal/AlertModal';
 import { requestUserList, requestRecommendDelete, requestLike } from './api/home_api';
+import { authFetch } from '../../utils/authFetch';
 
 const Home = () => {
 
@@ -24,9 +25,12 @@ const Home = () => {
 
   // 추천 리스트를 가져오는 함수
   const sparkUserList = async () => {
-    const token = localStorage.getItem("jwt");
     try {
-      const data = await requestUserList(memberInfo, token);
+      const res = await authFetch('http://localhost:8888/spark/api/recommend', {
+        method: 'POST',
+        body: JSON.stringify(memberInfo),
+      });
+      const data = await res.json();
       setRecommendations(data);
       console.log('추천 리스트:', data);
     } catch (error) {

--- a/src/page/Home/api/home_api.js
+++ b/src/page/Home/api/home_api.js
@@ -1,12 +1,10 @@
+import { authFetch } from '../../../utils/authFetch';
 
 // 메인 추천리스트 요청 api
-export const requestUserList = async (memberInfo, token) => {
-    const res = await fetch('http://localhost:8888/spark/api/recommend', {
+export const requestUserList = async (memberInfo) => {
+
+    const res = await authFetch('http://localhost:8888/spark/api/recommend', {
         method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-            'Authorization': `Bearer ${token}`,
-        },
         body: JSON.stringify(memberInfo),
     });
 
@@ -20,13 +18,9 @@ export const requestUserList = async (memberInfo, token) => {
 
 
 // x버튼 : 추천 제외 요청 api
-export const requestRecommendDelete = async (hiddenId, hiddenTarget, token) => {
-  const res = await fetch('http://localhost:8888/spark/api/recommendDelete', {
+export const requestRecommendDelete = async (hiddenId, hiddenTarget) => {
+  const res = await authFetch('http://localhost:8888/spark/api/recommendDelete', {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'Authorization': `Bearer ${token}`,
-    },
     body: JSON.stringify({ hiddenId, hiddenTarget }),
   });
 
@@ -37,13 +31,9 @@ export const requestRecommendDelete = async (hiddenId, hiddenTarget, token) => {
 
 
 // ♥ 버튼 : 좋아요 신청 api
-export const requestLike = async (requestId, responseId, token) => {
-  const res = await fetch('http://localhost:8888/spark/api/like', {
+export const requestLike = async (requestId, responseId) => {
+  const res = await authFetch('http://localhost:8888/spark/api/like', {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'Authorization': `Bearer ${token}`,
-    },
     body: JSON.stringify({ requestId, responseId }),
   });
 

--- a/src/page/Login/Login.jsx
+++ b/src/page/Login/Login.jsx
@@ -5,7 +5,7 @@ import { useAuthContext } from "../../context/AuthContext";
 const Login = () => {
   const [id, setId] = useState("");
   const [pwd, setPwd] = useState("");
-  const { setLoginCheck, setMemberInfo,setStep } = useAuthContext();
+  const { setStep } = useAuthContext();
   const navi = useNavigate();
   
   
@@ -34,15 +34,12 @@ const Login = () => {
 
 
       localStorage.setItem("jwt", accessToken);
-      setLoginCheck(true);
       alert("로그인 성공!");
-      setMemberInfo(data.memberDto);
-
       if (loginStatus === 'A') { // 회원가입 후 처음 로그인시 정보입력페이지로!
         setStep(1);
-        navi("/insertInfo");
+        window.location.href = "/insertInfo";
       } else {
-        navi("/");
+        window.location.href = "/";
       }
 
 

--- a/src/page/Mypage/Mypage.jsx
+++ b/src/page/Mypage/Mypage.jsx
@@ -4,40 +4,52 @@ import { useAuthContext } from '../../context/AuthContext';
 const Mypage = () => {
 
   const navigate = useNavigate();
-  const { setLoginCheck } = useAuthContext();
+  // 로그인 상태, 사용자 정보 상태 모두 초기화할 수 있도록 useAuthContext에서 가져옴
+  const { setLoginCheck, setMemberInfo, setMemId } = useAuthContext();
 
-  const logingOut= async ()=>{
-    
+  // 로그아웃 함수
+  const logingOut = async () => {
     const confirmLogout = window.confirm('로그아웃 하시겠습니까?');
-    
-    if(confirmLogout){
-      
-      try{
+    if (confirmLogout) {
+      try {
+        // 서버에 로그아웃 요청
+        const token = localStorage.getItem('jwt');
         const res = await fetch('http://localhost:8888/spark/api/logout', {
-          method : 'POST',
-          credentials : 'include'
+          method: 'POST',
+          credentials: 'include',
+          headers: {
+            'Authorization': `Bearer ${token}`,
+            'Content-Type': 'application/json'
+          }
         });
+        // 응답 상태 및 메시지 확인
+        let result = {};
+        try {
+          result = await res.json();
+        } catch (e) {}
+        console.log('로그아웃 응답 status:', res.status, 'body:', result);
 
-        if(res.ok){
-          // 서버에서 처리 성공
+        if (res.ok) {
+          // 1. 토큰 등 모든 사용자 정보 localStorage에서 제거
           localStorage.removeItem('jwt'); // access token 제거
           localStorage.removeItem('refreshToken'); // refresh token 제거
+          // 2. Context의 사용자 상태도 모두 초기화
           setLoginCheck(false); // 로그인 상태 false로 초기화
-          navigate('/login'); // 로그인 페이지로 리다이렉트
-          console.log('로그인 성공')
+          setMemberInfo(null);  // 사용자 정보 초기화
+          setMemId(null);       // memId 초기화
+          // 3. 로그인 페이지로 이동
+          navigate('/login');
+          console.log('로그아웃 성공');
         } else {
+          alert('로그아웃 실패: ' + (result.message || res.status));
           console.log('로그아웃 실패');
         }
-  
-      } catch (err){
+      } catch (err) {
         console.error('로그아웃 요청 실패:', err);
+        alert('로그아웃 요청 실패: ' + err.message);
       }
-
-    };
-
+    }
   };
-  
-
 
   return (
     <div>
@@ -52,4 +64,3 @@ const Mypage = () => {
 }
 
 export default Mypage
-   

--- a/src/page/likePage/Like.jsx
+++ b/src/page/likePage/Like.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useAuthContext } from "../../context/AuthContext";
 import { requestLikeList } from './api/like_api';
 
@@ -10,38 +10,36 @@ const Like = () => {
   const { memId, loading } = useAuthContext();
   const [likeList, setLikeList] = useState([]);
 
-  console.log('memId : ', memId, '| type:', typeof memId);
-
-
-
-
-  const sparkLikeList = useCallback(async () => {
-    const token = localStorage.getItem("jwt");
-    try {
-      const data = await requestLikeList(memId, token);
-      setLikeList(data);
-      console.log("좋아요 리스트:", data);
-    } catch (error) {
-      console.error(error);
-    }
-  }, [memId]); // memId가 바뀌면 sparkLikeList도 바뀌도록
-  // 만약 의존성배열에 안넣을시에는 memId가 바뀌어도 sparkLikeList는 초기 memId만 기억하고 있어서
-  // 오래된 ID로 계속 API 요청하게 되는 심각한 버그가 생길 수 있다.
+  console.log('[Like.jsx] 렌더링 - memId : ', memId, '| type:', typeof memId, '| loading:', loading);
 
 
   useEffect(() => {
-    if (!loading && memId) {
-      sparkLikeList();
+    console.log('[Like.jsx] useEffect 진입 - memId:', memId, '| loading:', loading);
+    if (loading) {
+      console.log('[Like.jsx] 아직 로딩 중');
+      return;
     }
-  }, [loading, memId, sparkLikeList]);
-  /*
-    ESLint 경고 : useEffect 의존성 배열에 포함되지 않았기 때문에 
-    React는 useEffect가 정확히 언제 다시 실행될지를 추적해야 한다.
-    만약 sparkLikeList 함수가 변경되면 useEffect를 다시 실행해야 할 수도 있는데, 
-    의존성 배열에 없으면 그걸 감지할 수 없다.
-    따라서 이 오류가 거슬리기에 해결방법은 useCallback 을 사용하여
-    의존성 배열에 추가한다.
-  */
+    if (!memId) {
+      console.log('[Like.jsx] memId 없음, 리스트 불러오지 않음');
+      setLikeList([]);
+      return;
+    }
+    const fetchLikeList = async () => {
+      try {
+        console.log('[Like.jsx] fetchLikeList 실행 - memId:', memId);
+        const data = await requestLikeList(memId); // 최신 구조: token 파라미터 없이
+        setLikeList(data);
+        console.log('[Like.jsx] 좋아요 리스트:', data);
+      } catch (error) {
+        setLikeList([]);
+        console.error('[Like.jsx] 좋아요 리스트 에러:', error);
+      }
+    };
+    fetchLikeList();
+  }, [loading, memId]);
+  
+
+  console.log('[Like.jsx] 렌더링 완료 - likeList:', likeList);
 
 
   return (

--- a/src/page/likePage/api/like_api.js
+++ b/src/page/likePage/api/like_api.js
@@ -1,13 +1,10 @@
+import { authFetch } from '../../../utils/authFetch';
+
 // 메인 추천리스트 요청 api
-export const requestLikeList = async (memId, token) => {
-    const res = await fetch('http://localhost:8888/spark/api/me/likeList', {
+export const requestLikeList = async (memId) => {
+    const res = await authFetch('http://localhost:8888/spark/api/me/likeList', {
         method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-            'Authorization': `Bearer ${token}`,
-        },
         body: JSON.stringify({ memId }),
-        
     });
     console.log("보내는 memId:", memId);
     console.log("보내는 JSON.stringify:", JSON.stringify({ memId }));

--- a/src/utils/authFetch.js
+++ b/src/utils/authFetch.js
@@ -1,0 +1,35 @@
+// src/utils/authFetch.js
+// 인증 토큰 자동 갱신 fetch 함수 (공통 유틸)
+
+export async function authFetch(url, options = {}) {
+  let accessToken = localStorage.getItem('jwt');
+  if (!options.headers) options.headers = {};
+  options.headers['Authorization'] = `Bearer ${accessToken}`;
+  options.headers['Content-Type'] = 'application/json';
+  options.credentials = 'include';
+
+  let res = await fetch(url, options);
+
+  // 토큰이 만료된 경우(401 또는 403)
+  if (res.status === 401 || res.status === 403) {
+    // refresh 요청
+    const refreshRes = await fetch('http://localhost:8888/spark/api/refresh', {
+      method: 'POST',
+      credentials: 'include',
+    });
+    const refreshData = await refreshRes.json();
+
+    if (refreshData.accessToken) {
+      // 새 토큰 저장
+      localStorage.setItem('jwt', refreshData.accessToken);
+      // 새 토큰으로 다시 요청
+      options.headers['Authorization'] = `Bearer ${refreshData.accessToken}`;
+      res = await fetch(url, options);
+    } else {
+      // refresh도 실패하면 로그아웃 처리
+      localStorage.removeItem('jwt');
+      throw new Error('로그인 만료');
+    }
+  }
+  return res;
+}


### PR DESCRIPTION
1. 각 api 요청시 리프레시 검사하는 로직 구현 
2. 토큰 관련으로 인해 추천리스트와 좋아요리스트 데이터가 제대로 불러와지지 않는 문제 해결

하지만 토큰 문제 해결로만 좋아요 리스트 문제는 해결되진 않았음

**<문제/원인>**
로그인 성공 후 SPA 라우팅(navigate)만 했었음
즉, 이게 뭔 뜻이냐면 말 그대로 컴퍼넌트만 교체되는거임
useEffect 로 감싼 로직은 한번만 실행되고나면 재실행 하지 않음
즉, 로컬스토리지에 새 토큰을 저장했어도 이미 실행된 initAuth 함수는 다시 실행되지 않아서 
새 토큰을 읽지 못하고 memId등의 정보를 갱신하지 못했던 거임



**<해결>**
로그인 성공 시 새로고침하면서 해당 상태에 맞게 페이지 이동시키면 끝임
window.location.href 사용하여 로직 구현함
 